### PR TITLE
SDCC 3.0.0 Compatibility Fix

### DIFF
--- a/specan/src/specan.c
+++ b/specan/src/specan.c
@@ -21,7 +21,6 @@
 #include "ioCCxx10_bitdef.h"
 #include "display.h"
 #include "keys.h"
-#include "5x7.h"
 #include "stdio.h"
 #include "specan.h"
 #include "pm.h"


### PR DESCRIPTION
Howdy Mike,

There is an unnecessary include in specan.c that prevents linking in SDCC 3.0.0.  This patch removed that including, allowing firmware to successfully compile.

Thank you kindly,
--Travis
