### PR TITLE
Support TX'ing more than once, set MHz/baudrate easily via ints, support recent sdcc

### DIFF
--- a/garage/opensesame/helpers.h
+++ b/garage/opensesame/helpers.h
@@ -1,0 +1,55 @@
+// helper functions for cc111x
+// -samy kamkar
+
+#include <math.h>
+
+#ifdef CC1110
+#define MHZ 26
+#elif CC1111
+#define MHZ 48
+#else
+#error Please define CC1110 or CC1111 so clock can be determined.
+#endif
+
+// set FREQ registers in cc111x from a float
+void setFreq(float freq, char *FREQ2, char *FREQ1, char *FREQ0)
+{
+	float freqMult = (0x10000 / 1000000.0) / MHZ;
+	u32 num = freq * freqMult;
+
+	*FREQ2 = num >> 16;
+	*FREQ1 = (num >> 8) & 0xFF;
+	*FREQ0 = num & 0xFF;
+}
+
+// set baudrate registers from a float
+void setBaud(float drate, char *MDMCFG4, char *MDMCFG3)
+{
+	u8 drate_e = 0;
+	u8 drate_m = 0;
+	u8 e;
+	float m = 0;
+
+	for (e = 0; e < 16; e++)
+	{
+
+		m = (drate * powf(2,28) / (powf(2,e)* (MHZ*1000000.0))-256) + .5;
+		if (m < 256)
+		{
+			drate_e = e;
+			drate_m = m;
+			break;
+		}
+	}
+
+	drate = 1000000.0 * MHZ * (256+drate_m) * powf(2,drate_e) / powf(2,28);
+
+	*MDMCFG3 = drate_m;
+#ifndef MDMCFG4_DRATE_E
+#define MDMCFG4_DRATE_E 0x0F
+#endif
+  *MDMCFG4 &= ~MDMCFG4_DRATE_E;
+  *MDMCFG4 |= drate_e;
+}
+
+

--- a/garage/opensesame/opensesame.c
+++ b/garage/opensesame/opensesame.c
@@ -1,9 +1,13 @@
+#define BAUDRATE 5000
+#define FREQ 390000000 // frequency in Hz (390MHz)
+#define CC1110
+
 #include <cc1110.h>
 #include "ioCCxx10_bitdef.h"
 #include "display.h"
 #include "keys.h"
-#include "5x7.h"
 #include "stdio.h"
+#include "helpers.h"
 
 #define HIBYTE(a)     (u8) ((u16)(a) >> 8 )
 #define LOBYTE(a)     (u8)  (u16)(a)
@@ -38,11 +42,11 @@ typedef struct {
 
 static volatile u8 txdone = 0;
 
-xdata DMA_DESC dmaConfig;
+__xdata DMA_DESC dmaConfig;
 
 /* raw ook code captured from garage door opener */
 #define LEN 29
-xdata u8 buf[] = {
+__xdata u8 buf[] = {
 	0xaa, 0xaa, 0xaa, 0x00, 0x4d, 0x34, 0xd3,
 	0x49, 0x36, 0xd2, 0x49, 0xb6, 0xda, 0x6d,
 	0x34, 0xdb, 0x69, 0xb4, 0x92, 0x69, 0x36,
@@ -84,14 +88,11 @@ int main(void)
     FSCTRL0   = 0x00;
 
 	/* 390 MHz */
-	FREQ2     = 0x0F;
-	FREQ1     = 0x00;
-	FREQ0     = 0x00;
+	setFreq(FREQ, &FREQ2, &FREQ1, &FREQ0);
     CHANNR    = 0x00;
 
 	/* maximum channel bandwidth, 5000 baud */
-    MDMCFG4   = 0x07;
-    MDMCFG3   = 0x93;
+		setBaud(BAUDRATE, &MDMCFG4, &MDMCFG3);
 
 	/* DC blocking enabled, OOK/ASK */
 	MDMCFG2   = 0x30; // no preamble/sync
@@ -160,7 +161,8 @@ int main(void)
 
     	RFST = RFST_SIDLE;
 
-		sleepMillis(1000);
+		sleepMillis(500);
+		txdone = 0;
 	}
 }
 


### PR DESCRIPTION
Support TX'ing more than once, set MHz/baudrate easily via ints, support recent sdcc (3.x, backwards compatible with 2.9)
